### PR TITLE
MutableMapping is now under collections.abc

### DIFF
--- a/states/helpers.py
+++ b/states/helpers.py
@@ -1,6 +1,6 @@
 from termcolor import colored
 from copy import deepcopy
-import collections
+import collections.abc
 
 
 class FlatDictDiffer(object):
@@ -41,7 +41,7 @@ def flatten(d, pkey='', sep='/'):
     items = []
     for k in d:
         new = pkey + sep + k if pkey else k
-        if isinstance(d[k], collections.MutableMapping):
+        if isinstance(d[k], collections.abc.MutableMapping):
             items.extend(flatten(d[k], new, sep=sep).items())
         else:
             items.append((sep + new, d[k]))


### PR DESCRIPTION
# Changes

## What

- Import `collections.abc` for `MutableMapping`

## Why

- Class moved as of Python 3.3
- Fixes #31 

## Areas of concern

- Likely breaks compatibility with Python < 3.3

## Relevant Links

- https://docs.python.org/3.11/library/collections.abc.html#collections.abc.MutableMapping
- https://github.com/runtheops/ssm-diff/issues/31
